### PR TITLE
Replacing sklearn externals joblib with joblib

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The code uses a lot type hints so you'll probably need at least Python 3.6.
 
 2. Install dependencies  
 ```commandline
-pip install docopt tqdm pyfancy sklearn scipy
+pip install docopt tqdm pyfancy sklearn scipy joblib
 ```
  
 ### Usage

--- a/free_wilson_regression.py
+++ b/free_wilson_regression.py
@@ -6,7 +6,7 @@ import re
 import numpy as np
 import pandas as pd
 from pyfancy import pyfancy
-from sklearn.externals import joblib
+import joblib
 from sklearn.linear_model import Ridge
 from sklearn.metrics import r2_score
 


### PR DESCRIPTION
Hi Pat,

Thanks for creating this very useful script! This PR replaces the sklearn.externals.joblib import (which is deprecated in sklearn 0.21 and will be removed in 0.23) with the standalone joblib.